### PR TITLE
1.4.6

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,31 +1,24 @@
 {
-  "targets": [
-    {
-      "target_name": "watchdog",
-      "sources": [ "src/watchdog.cc" ],
-      "cflags": ["-O2", "-D_FORTIFY_SOURCE=2"],
-      'msvs_configuration_attributes': {
-        'SpectreMitigation': 'Spectre'
-      },
-      'msvs_settings': {
-        'VCCLCompilerTool': {
-          'AdditionalOptions': [
-            '/guard:cf',
-            '/sdl',
-            '/W3',
-            '/we4146',
-            '/we4244',
-            '/we4267',
-            '/ZH:SHA_256'
-          ]
-        },
-        'VCLinkerTool': {
-          'AdditionalOptions': [
-            '/DYNAMICBASE',
-            '/guard:cf'
-          ]
+    "targets": [
+        {
+            "target_name": "watchdog",
+            "sources": ["src/watchdog.cc"],
+            "cflags": ["-O2", "-D_FORTIFY_SOURCE=2"],
+            "msvs_configuration_attributes": {"SpectreMitigation": "Spectre"},
+            "msvs_settings": {
+                "VCCLCompilerTool": {
+                    "AdditionalOptions": [
+                        "/guard:cf",
+                        "/sdl",
+                        "/W3",
+                        "/we4146",
+                        "/we4244",
+                        "/we4267",
+                        "/ZH:SHA_256",
+                    ]
+                },
+                "VCLinkerTool": {"AdditionalOptions": ["/DYNAMICBASE", "/guard:cf"]},
+            },
         }
-      }
-    }
-  ]
+    ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
         {
             "target_name": "watchdog",
             "sources": ["src/watchdog.cc"],
-            "cflags": ["-O2", "-D_FORTIFY_SOURCE=2"],
+            "cflags": ["-O2", "-fstack-protector-strong"],
             "msvs_configuration_attributes": {"SpectreMitigation": "Spectre"},
             "msvs_settings": {
                 "VCCLCompilerTool": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "native-watchdog",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "native-watchdog",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-watchdog",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "A native module that kills the current process if the event loop is unresponsive",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
This PR formats the binding.gyp file and adds the stack-protector-strong flag for Linux builds.

I confirmed that the binary grows by under 100 bytes between compiling with -fno-stack-protector and with -fstack-protector-strong. I believe that this library is also not used in any performance-critical contexts and therefore does not need performance testing.