### PR TITLE
chore: rename package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "native-watchdog",
+  "name": "@vscode/native-watchdog",
   "version": "1.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "native-watchdog",
+      "name": "@vscode/native-watchdog",
       "version": "1.4.6",
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "native-watchdog",
+  "name": "@vscode/native-watchdog",
   "version": "1.4.6",
   "description": "A native module that kills the current process if the event loop is unresponsive",
   "main": "index.js",

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -25,7 +25,7 @@ extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
   parameters:
     npmPackages:
-      - name: native-watchdog
+      - name: node-native-watchdog
 
         buildSteps:
           - script: npm ci


### PR DESCRIPTION
This PR changes the package name in package.json so that we can publish it more easily to npm. It also changes the package name in pipeline.yml so that running the pipeline creates a new TSA entry. The previous TSA codebase has been retired and cannot be used, which is why the native-watchdog pipeline has only been partially succeeding for the past while. 