### PR TITLE
chore: override TSA codebase name

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -25,7 +25,7 @@ extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
   parameters:
     npmPackages:
-      - name: node-native-watchdog
+      - name: native-watchdog
 
         buildSteps:
           - script: npm ci
@@ -50,6 +50,12 @@ extends:
             displayName: Test
 
         apiScanSoftwareName: vscode-native-watchdog
-        apiScanSoftwareVersion: '1.4'
+        apiScanSoftwareVersion: "1.4"
 
         publishPackage: ${{ parameters.publishPackage }}
+
+    # The old TSA config has been retired, so we're forced to use a new one
+    # to continue uploading scan results.
+    tsa:
+      config:
+        codebaseName: vscode-native-watchdog


### PR DESCRIPTION
TSA is a service that allows us to keep track of our compliance scan results, but the node-native-watchdog TSA codebase has been retired for unknown reasons, causing the TSAUpload task to fail and all recent pipeline runs to be partiallySucceeded.

This PR allows us to upload compliance scan results onto a new TSA codebase.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=391885&view=results